### PR TITLE
Tutorial references 'Flight' menu, which should be 'File' menu instead

### DIFF
--- a/src/en/TUTORIALIFR.rst
+++ b/src/en/TUTORIALIFR.rst
@@ -41,7 +41,7 @@ The tutorial assumes the following preconditions:
 Prepare Flight
 ~~~~~~~~~~~~~~
 
-Use ``Flight`` -> :ref:`reset-for-new-flight`
+Use ``File`` -> :ref:`reset-for-new-flight`
 |Reset all for a new Flight| before each flight to get a clean base for
 fuel calculation and other functions. Deselect
 ``Create an empty flight plan`` in the dialog if the flight plan is

--- a/src/en/TUTORIALVFR.rst
+++ b/src/en/TUTORIALVFR.rst
@@ -24,7 +24,7 @@ The flight plan is: *Meythet (LFLP) / Runway 04 to Challes-Les-Eaux (LFLE) Dista
 Prepare Flight
 ~~~~~~~~~~~~~~
 
-I'd recommend to get use ``Flight`` -> :ref:`reset-for-new-flight`
+I'd recommend to get use ``File`` -> :ref:`reset-for-new-flight`
 |Reset all for a new Flight| before each flight to get a clean base for
 fuel calculation and other functions. Deselect
 ``Create an empty flight plan`` in the dialog if your plan is


### PR DESCRIPTION
In the tutorial, it's recommended to use the menu option 'Reset all for a new flight' in the 'Flight' menu, but that option is in the 'File' menu instead (at least on mac).

<img width="577" height="248" alt="image" src="https://github.com/user-attachments/assets/23a4aa63-6c16-42c9-b879-3da94830acb7" />

I don't know much about QT development, but it matches the declaration of the menu with the title 'File' at https://github.com/albar965/littlenavmap/blob/872d2ddf3440ff0a22bbf5eb662c221be9ff9bde/src/gui/mainwindow.ui#L42 